### PR TITLE
Change default get_tile params

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: terrainr
 Type: Package
 Title: Landscape Visualizations in R and 'Unity'
-Version: 0.3.1.9000
+Version: 0.3.1.9001
 Authors@R: c(
     person(given = "Michael",
            family = "Mahoney",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# terrainr 0.3.1.9000
+# terrainr 0.3.1.9001
 * Current development version (will be 0.4.0)
 * Breaking changes:
     * Three changes in how `vector_to_overlay` deals with missing CRS in 
@@ -14,6 +14,14 @@
           your input data has no CRS, `vector_to_overlay` will warn about 
           assuming the raster CRS. Set to `TRUE` to error or `FALSE` to ignore
           the warning.
+    * NAIP imagery is now downloaded with `transparent = "false"` to
+      minimize the number of times the backup method to `merge_rasters` (see 
+      below) is called. To restore the old behavior, set `transparent = "true"` 
+      in either `get_tiles` or `hit_national_map_api`.
+    * `get_tiles` will now infer `bboxSR` and `imageSR` from provided `sf` or
+      `Raster` objects if not otherwise specified. To restore the old behavior,
+      set `bboxSR` and `imageSR` to `4326` in `get_tiles` (or set your data's 
+      CRS to 4326 before calling `get_tiles`).
 * Improvements and bug fixes:
     * `merge_rasters` can once again handle merging mixed-band rasters (such as
       NAIP images with and without alpha bands). At the moment this is using the

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,9 @@
       `ggplot2` is required
     * `calc_haversine_distance` (not exported) now assumes it's been provided
       with degrees. `coord_units` has been removed as an argument.
+    * `get_tiles.terrainr_bounding_box` has been removed; it should no longer be
+      possible for users to have `terrainr_bounding_box` objects unless they 
+      were using non-exported functionality.
 
 # terrainr 0.3.1
 * First CRAN submission!

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@
           your input data has no CRS, `vector_to_overlay` will warn about 
           assuming the raster CRS. Set to `TRUE` to error or `FALSE` to ignore
           the warning.
+* Improvements and bug fixes:
+    * `merge_rasters` can once again handle merging mixed-band rasters (such as
+      NAIP images with and without alpha bands). At the moment this is using the
+      older, slower implementation and will raise a warning. (#30, #32).
 * Internal changes:
     * Removed code to check for `ggplot2` from `vector_to_overlay` now that
       `ggplot2` is required

--- a/R/get_tiles.R
+++ b/R/get_tiles.R
@@ -103,6 +103,19 @@ get_tiles.sf <- function(data,
                          georeference = TRUE,
                          ...) {
 
+  dots <- list(...)
+  if (!any(names(dots) == "bboxSR")) {
+    bboxSR <- ifelse(is.na(sf::st_crs(data)$epsg),
+                     4326,
+                     sf::st_crs(data)$epsg)
+  } else bboxSR <- dots[["bboxSR"]]
+
+  if (!any(names(dots) == "imageSR")) {
+    imageSR <- ifelse(is.na(sf::st_crs(data)$epsg),
+                      4326,
+                      sf::st_crs(data)$epsg)
+  } else imageSR <- dots[["imageSR"]]
+
   data <- sf::st_bbox(data)
   bl <- c("lng" = data[["xmin"]], "lat" = data[["ymin"]])
   tr <- c("lng" = data[["xmax"]], "lat" = data[["ymax"]])
@@ -116,6 +129,8 @@ get_tiles.sf <- function(data,
     services = services,
     verbose = verbose,
     georeference = georeference,
+    bboxSR = bboxSR,
+    imageSR = imageSR,
     ...
   )
 
@@ -156,6 +171,19 @@ get_tiles.Raster <- function(data,
                              georeference = TRUE,
                              ...) {
 
+  dots <- list(...)
+  if (!any(names(dots) == "bboxSR")) {
+    bboxSR <- ifelse(is.na(sf::st_crs(data)$epsg),
+                     4326,
+                     sf::st_crs(data)$epsg)
+  } else bboxSR <- dots[["bboxSR"]]
+
+  if (!any(names(dots) == "imageSR")) {
+    imageSR <- ifelse(is.na(sf::st_crs(data)$epsg),
+                      4326,
+                      sf::st_crs(data)$epsg)
+  } else imageSR <- dots[["imageSR"]]
+
   data <- raster::extent(data)
   bl <- c("lng" = data@xmin, "lat" = data@ymin)
   tr <- c("lng" = data@xmax, "lat" = data@ymax)
@@ -189,31 +217,6 @@ get_tiles.list <- function(data,
   get_tiles_internal(
     bl = bbox@bl,
     tr = bbox@tr,
-    output_prefix = output_prefix,
-    side_length = side_length,
-    resolution = resolution,
-    services = services,
-    verbose = verbose,
-    georeference = georeference,
-    ...
-  )
-
-}
-
-#' @rdname get_tiles
-# nolint start
-get_tiles.terrainr_bounding_box <- function(data,
-                                            output_prefix = tempfile(),
-                                            side_length = NULL,
-                                            resolution = 1,
-                                            services = "elevation",
-                                            verbose = FALSE,
-                                            georeference = TRUE,
-                                            ...) {
-# nolint end
-  get_tiles_internal(
-    bl = data@bl,
-    tr = data@tr,
     output_prefix = output_prefix,
     side_length = side_length,
     resolution = resolution,

--- a/R/hit_api.R
+++ b/R/hit_api.R
@@ -118,7 +118,11 @@ hit_national_map_api <- function(bbox,
       interpolation = "+RSP_BilinearInterpolation",
       f = "json"
     ),
-    # note: this format purposefully excludes transparent from NAIP downloads
+    # purposefully exclude transparency from NAIP downloads
+    "USGSNAIPPlus" = c(
+      standard_png_args[names(standard_png_args) != "transparent"],
+      transparent = "false"
+      ),
     "nhd" = c(layers = 0, standard_png_args),
     standard_png_args
   )

--- a/R/merge_rasters.R
+++ b/R/merge_rasters.R
@@ -42,9 +42,8 @@ merge_rasters <- function(input_rasters,
                    options = options),
     error = function(e) {
       warning(
-        "Received error from gdalwarp:\n",
-        e,
-        "\nTrying another method.")
+        "\nReceived error from gdalwarp.",
+        "Trying another method. This may take longer than normal...")
       merge_rasters_deprecated(input_rasters, output_raster, options)
     }
   )
@@ -168,6 +167,10 @@ merge_rasters_deprecated <- function(
   }
 
   if (exists("tmprst")) lapply(tmprst, unlink)
+
+  message("...done.",
+          "The alternate method seems to have worked!",
+          "If your merged output looks right, you can ignore the above error.")
 
   return(output_list)
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -271,7 +271,7 @@
   ],
   "releaseNotes": "https://github.com/ropensci/terrainr/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/terrainr/blob/main/README.md",
-  "fileSize": "3123.028KB",
+  "fileSize": "3123.232KB",
   "contIntegration": "https://codecov.io/gh/ropensci/terrainr",
   "developmentStatus": ["https://lifecycle.r-lib.org/articles/stages.html#maturing", "https://www.repostatus.org/#active"],
   "keywords": [

--- a/codemeta.json
+++ b/codemeta.json
@@ -16,7 +16,7 @@
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.0.4 (2021-02-15)",
+  "runtimePlatform": "R version 4.0.5 (2021-03-31)",
   "author": [
     {
       "@type": "Person",
@@ -271,7 +271,7 @@
   ],
   "releaseNotes": "https://github.com/ropensci/terrainr/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/terrainr/blob/main/README.md",
-  "fileSize": "3117.751KB",
+  "fileSize": "3121.723KB",
   "contIntegration": "https://codecov.io/gh/ropensci/terrainr",
   "developmentStatus": ["https://lifecycle.r-lib.org/articles/stages.html#maturing", "https://www.repostatus.org/#active"],
   "keywords": [

--- a/man/get_tiles.Rd
+++ b/man/get_tiles.Rd
@@ -6,7 +6,6 @@
 \alias{get_tiles.sfc}
 \alias{get_tiles.Raster}
 \alias{get_tiles.list}
-\alias{get_tiles.terrainr_bounding_box}
 \title{A user-friendly way to get USGS National Map data tiles for an area}
 \usage{
 get_tiles(
@@ -54,17 +53,6 @@ get_tiles(
 )
 
 \method{get_tiles}{list}(
-  data,
-  output_prefix = tempfile(),
-  side_length = NULL,
-  resolution = 1,
-  services = "elevation",
-  verbose = FALSE,
-  georeference = TRUE,
-  ...
-)
-
-\method{get_tiles}{terrainr_bounding_box}(
   data,
   output_prefix = tempfile(),
   side_length = NULL,

--- a/tests/testthat/test-2-get_tiles_3dep.R
+++ b/tests/testthat/test-2-get_tiles_3dep.R
@@ -48,3 +48,36 @@ test_that("get_tiles fails as expected", {
   side_length = 8001
   ))
 })
+
+test_that("specifying SR works", {
+
+  dat <- data.frame(
+    lat = c(44.04905, 44.04911),
+    lng = c(-74.01188, -74.01179)
+  )
+
+  dat <- sf::st_as_sf(dat, coords = c("lng", "lat"))
+  dat <- sf::st_set_crs(dat, 4326)
+
+  output_tif <- vector("list", 4)
+  output_tif[1] <- get_tiles(dat)
+  output_tif[2] <- get_tiles(dat, bboxSR = 4326)
+  output_tif[3] <- get_tiles(dat, imageSR = 4326)
+  output_tif[4] <- get_tiles(dat, bboxSR = 4326, imageSR = 4326)
+
+  expect_equal(
+    brio::read_file_raw(output_tif[[1]]),
+    brio::read_file_raw(output_tif[[2]])
+  )
+
+  expect_equal(
+    brio::read_file_raw(output_tif[[1]]),
+    brio::read_file_raw(output_tif[[3]])
+  )
+
+  expect_equal(
+    brio::read_file_raw(output_tif[[1]]),
+    brio::read_file_raw(output_tif[[4]])
+  )
+
+})


### PR DESCRIPTION
<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR makes two substantive changes:

* It fixes #33 by setting the default value for transparency of NAIP images to "false"
* It infers SR from the CRS of input data, rather than assuming WGS84 for all cases

This PR also removes a little piece of dead code and continues dismantling the old S4 classes by removing `get_tiles.terrainr_bounding_box`.
