### PR TITLE
Force install of PROJ and GDAL on MacOS

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -62,14 +62,9 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
           
-      - name: Install macOS dependencies
-        if: runner.os == 'macOS'
-        run: |
-          brew install gdal
-          
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies = TRUE, type = "binary")
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -62,9 +62,15 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
           
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew install proj
+          brew install gdal
+          
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE, type = "binary")
+          remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -54,13 +54,19 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-      - name: Install system dependencies
+      - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
           while read -r cmd
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+          
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew install gdal
+          
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)


### PR DESCRIPTION
When `sf` is installed from source, not as a binary, it requires a system installation of GDAL to compile. Since MacOS binaries can take a while to promulgate, this means I need to be prepared for the time between sf updates and binaries.

GDAL on homebrew appears to drag in Proj7, which is not usable by `sf`, so I also need to install Proj8 before GDAL.
